### PR TITLE
Fix header breakpoint issue

### DIFF
--- a/packages/common/scss/common.scss
+++ b/packages/common/scss/common.scss
@@ -13,14 +13,19 @@ $enable-rounded: false;
 $theme-site-navbar-logo-height: 30px;
 $theme-site-navbar-logo-height-sm: 25px;
 
-$theme-site-header-breakpoints: (
-  hide-primary: 10000px,
-  hide-secondary: 610px,
-  hide-tertiary: 0,
-  small-logo: 667px,
-  small-text-primary: 10000px,
-  small-text-secondary: 740px
-) !default;
+$theme-site-header-breakpoints: () !default;
+// stylelint-disable-next-line scss/dollar-variable-default
+$theme-site-header-breakpoints: map-merge(
+  (
+    hide-primary: 10000px,
+    hide-secondary: 610px,
+    hide-tertiary: 0,
+    small-logo: 667px,
+    small-text-primary: 10000px,
+    small-text-secondary: 740px
+  ),
+  $theme-site-header-breakpoints
+);
 
 @import "../../node_modules/@base-cms/marko-web-theme-default/skins/orion/skin";
 @import "../../node_modules/@base-cms/marko-web-gtm/scss/slot";


### PR DESCRIPTION
When site-specific header breakpoints are defined (as in PW's case), the resulting set is not merged as expected -- the header breakpoints are overwritten to contain only the customized definitions, rather than the expected defaults + custom.

New: 
![image](https://user-images.githubusercontent.com/1778222/93646357-acbd8400-f9cb-11ea-8a4c-31c9c8b3bc95.png)

Current: 
![image](https://user-images.githubusercontent.com/1778222/93646377-b515bf00-f9cb-11ea-80a3-da56e5faa2f5.png)

